### PR TITLE
Fix Undefined property: stdClass::$column_name by stuheiss

### DIFF
--- a/src/Xethron/MigrationsGenerator/Generators/FieldGenerator.php
+++ b/src/Xethron/MigrationsGenerator/Generators/FieldGenerator.php
@@ -55,7 +55,7 @@ class FieldGenerator {
 				->where('table_schema', $this->database)
 				->where('table_name', $table)
 				->where('data_type', 'enum')
-				->get(['column_name','column_type']);
+				->get(['column_name as column_name','column_type as column_type']);
 			if ($result)
 				return $result;
 			else


### PR DESCRIPTION
Querying information_schema.columns returns upper cased column names on
some versions of mysqld. This is similar to an old bug in
laravel/framework. See https://github.com/laravel/framework/issues/20190

Fix by changing
    select column_name, column_type ...
to
    select column_name as column_name, column_type as column_type ...